### PR TITLE
Refactored auth architecture 

### DIFF
--- a/Nudge/NudgeApp.swift
+++ b/Nudge/NudgeApp.swift
@@ -10,6 +10,8 @@ import FirebaseCore
 
 @main
 struct NudgeApp: App {
+    
+    @State private var authViewModel = AuthViewModel()
 
     init() {
         FirebaseApp.configure()
@@ -17,7 +19,17 @@ struct NudgeApp: App {
 
     var body: some Scene {
         WindowGroup {
-            SignInView()
+            NavigationStack {
+                Group {
+                    if authViewModel.currentUser != nil {
+                        // Placeholder until main views are implemented
+                        Text(String(localized: "app_name"))
+                    } else {
+                        SignInView()
+                    }
+                }
+            }
+            .environment(authViewModel)
         }
     }
 }

--- a/Nudge/Services/FirebaseService.swift
+++ b/Nudge/Services/FirebaseService.swift
@@ -1,0 +1,19 @@
+import Foundation
+import FirebaseAuth
+
+final class FirebaseService {
+    
+    func signIn(email: String, password: String) async throws -> User {
+        let result = try await Auth.auth().signIn(withEmail: email, password: password)
+        return result.user
+    }
+    
+    func signUp(email: String, password: String) async throws -> User {
+        let result = try await Auth.auth().createUser(withEmail: email, password: password)
+        return result.user
+    }
+    
+    func signOut() throws {
+        try Auth.auth().signOut()
+    }
+}

--- a/Nudge/ViewModels/AuthViewModel.swift
+++ b/Nudge/ViewModels/AuthViewModel.swift
@@ -17,10 +17,21 @@ class AuthViewModel {
     var errorMessage: String?
     var isLoading: Bool = false
 
+    private let authService = FirebaseService()
+    private var authListener: AuthStateDidChangeListenerHandle?
+
     //==== Init ===========================================
 
-    init() {
-        self.currentUser = Auth.auth().currentUser
+   init() {
+        setupAuthListener()
+    }
+    
+    private func setupAuthListener() {
+        authListener = Auth.auth().addStateDidChangeListener { [weak self] _, user in
+            Task { @MainActor in
+                self?.currentUser = user
+            }
+        }
     }
 
     //==== Sign In =============================================
@@ -30,10 +41,9 @@ class AuthViewModel {
         errorMessage = nil
 
         do {
-            let result = try await Auth.auth().signIn(withEmail: email, password: password)
-            currentUser = result.user
-        } catch  {
-            errorMessage = error.localizedDescription
+            _ = try await authService.signIn(email: email, password: password)
+        } catch {
+            errorMessage = String(localized: "error_title")
         }
 
         isLoading = false
@@ -42,27 +52,25 @@ class AuthViewModel {
      //==== Sign Up =============================================
 
      func signUp(email: String, password: String) async {
-         isLoading = true
-         errorMessage = nil
+        isLoading = true
+        errorMessage = nil
 
-         do {
-             let result = try await Auth.auth().createUser(withEmail: email, password: password)
-             currentUser = result.user
-         } catch  {
-             errorMessage = error.localizedDescription
-         }
+        do {
+            _ = try await authService.signUp(email: email, password: password)
+        } catch {
+            errorMessage = String(localized: "error_save_failed")
+        }
 
-         isLoading = false
-     }
+        isLoading = false
+    }
 
       //==== Sign Out =============================================
 
       func signOut() {
-          do {
-              try Auth.auth().signOut()
-              currentUser = nil
-          } catch {
-              errorMessage = error.localizedDescription
-          }
-      }
+        do {
+            try authService.signOut()
+        } catch {
+            errorMessage = String(localized: "error_title")
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Refactored authentication architecture and implemented a dedicated service layer.
 
## Changes
- Created `FirebaseService` to handle all direct interactions with Firebase Auth.
- Refactored `AuthViewModel` to use the new service and implemented a reactive `AuthStateDidChangeListener`.
- Updated `NudgeApp` to manage root navigation and conditional view switching based on auth state.
 
## Why
- Standardized data flow by decoupling Firebase logic from the ViewModel.
- Improved readability and maintainability through a clear separation of concerns (MVVM + Service).
- Prepared backend/UI integration for the upcoming SignIn view and main app flow.
 
## Result
The authentication layer now supports a reactive, extensible structure that automatically manages user sessions and navigation.