### PR TITLE
refactor: updated Habit model with streak logic and Firestore-compatible properties

### DIFF
--- a/Nudge/Models/Habit.swift
+++ b/Nudge/Models/Habit.swift
@@ -9,9 +9,48 @@ import Foundation
 
 struct Habit: Identifiable, Codable {
 
-    let id: UUID
+    let id: String
+    let userId: String
     var name: String
     var icon: String
     var completedDates: [Date]
     var createdAt: Date
+}
+
+//==== Computed Properties =============================================
+
+extension Habit {
+
+    var isCompletedToday: Bool {
+        let calendar = Calendar.current
+        return completedDates.contains { calendar.isDateInToday($0) }
+    }
+
+    var currentStreak: Int {
+        let calendar = Calendar.current
+
+        let uniqueDays = Set(
+            completedDates.map { calendar.startOfDay(for: $0) }
+        )
+        let sortedDays = uniqueDays.sorted(by: >)
+
+        guard let latest = sortedDays.first else { return 0 }
+
+        let today = calendar.startOfDay(for: Date())
+        let daysSinceLatest =
+            calendar.dateComponents([.day], from: latest, to: today).day ?? 0
+
+        guard daysSinceLatest <= 1 else { return 0 }
+
+        var streak = 1
+        var expected = calendar.date(byAdding: .day, value: -1, to: latest)!
+
+        for day in sortedDays.dropFirst() {
+            guard day == expected else { break }
+            streak += 1
+            expected = calendar.date(byAdding: .day, value: -1, to: expected)!
+        }
+
+        return streak
+    }
 }


### PR DESCRIPTION
## Summary
Refactored the Habit model to be Firestore-compatible and added streak logic as computed properties.

## Changes
- Updated `Habit.swift` with `id: String` and `userId: String` for Firestore compatibility
- Added `isCompletedToday` and `currentStreak` as computed properties in an extension

## Why
- `id` must be a `String` to map to Firestore document IDs
- `userId` links each habit to the authenticated user
- Streak logic belongs in the model as it operates purely on the model's own data
- Extension keeps the file organized while maintaining single responsibility

## Result
Habit model is Firestore-ready and contains all domain logic needed for streak tracking.