### PR TITLE
feat: added HabitServiceProtocol, HabitService and HabitViewModel

### DIFF
--- a/Nudge/Services/Habit/HabitService.swift
+++ b/Nudge/Services/Habit/HabitService.swift
@@ -1,0 +1,57 @@
+//
+//  HabitService.swift
+//  Nudge
+//
+//  Created by Linnéa on 2026-05-01.
+//
+
+Import Foundation
+import FirebaseFirestore
+
+final class HabitService: HabitServiceProtocol {
+
+    //==== Properties =============================================
+
+    private let db = Firestore.firestore()
+    private let collection = "habits"
+
+    //==== Fetch =============================================
+
+    func fetchHabits(for userId: String) async trhows -> [Habit] {
+        let snapshot = try await db.collection(collection)
+            .whereField("userId", isEqualTo: userId)
+            .getDDocuments()
+
+        return snapshot.documents.compactMap { document in
+            try? document.data(as: Habit.self)
+        }
+    }
+
+    //==== Add =============================================
+
+    func addHabit(_ habit: Habit) async throws {
+        try db.collection(collection)
+            .document(habit.id)
+            .setData(from: habit)
+    }
+
+    //==== Delete =============================================
+
+    func deleteHabit(_ habit: Habit) async throws {
+        try db.collection(collection)
+            .document(habit.id)
+            .delete()
+    }
+
+    //==== Check-In =============================================
+
+    func checkIn(_ habit: Habit, on date: Date) async throws {
+        let timestamp = Timestamp(date: date)
+        try await db.collection(collection)
+            .document(habit.id)
+            .updateData([
+                "completedDates": FieldValue.arrayUnion([timestamp])
+            ])
+    }
+
+}

--- a/Nudge/Services/Habit/HabitServiceProtocol.swift
+++ b/Nudge/Services/Habit/HabitServiceProtocol.swift
@@ -1,0 +1,15 @@
+//
+//  HabitServiceProtocol.swift
+//  Nudge
+//
+//  Created by Linnéa on 2026-05-01.
+//
+
+import Foundation
+
+protocol HabitServiceProtocol {
+    func fetchHabits(for userId: String) async throws -> [Habit]
+    func addHabit(_ habit: Habit) async throws
+    func deleteHabit(_ habit: Habit) async throws
+    func checkIn(_ habit: Habit, on date: Date) async throws
+}

--- a/Nudge/ViewModels/HabitViewModel.swift
+++ b/Nudge/ViewModels/HabitViewModel.swift
@@ -8,6 +8,87 @@
 import Foundation
 
 @Observable
-class HabitViewModel {
+final class HabitViewModel {
 
+    //==== State =============================================
+
+    private(set) var habits: [Habit] = []
+    private(set) var isLoading: Bool = false
+    var errorMessage: String?
+
+    //==== Dependencies =============================================
+
+    private let habitService: HabitServiceProtocol
+
+    //==== Init =============================================
+
+    init(habitService: HabitServiceProtocol = HabitService()) {
+        self.habitService = habitService
+    }
+
+    //==== Fetch =============================================
+
+    func fetchHabits(for userId: String) async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            habits = try await habitService.fetchHabits(for: userId)
+        } catch {
+            errorMessage = String(localized: "error_save_failed")
+        }
+
+        isLoading = false
+    }
+   
+   //==== Add =======================================
+
+   func addHabit(name: String, icon: String, userId: String) async {
+        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+            errorMessage = String(localized: "error_empty_name")
+            return
+        }
+
+        let habit = Habit(
+            id: UUID().uuidString,
+            userId: userId,
+            name: name,
+            icon: icon,
+            completedDates: [],
+            createdAt: Date()
+        )
+
+        do {
+            try await habitService.addHabit(habit)
+            habits.append(habit)
+        } catch {
+            errorMessage = String(localized: "error_save_failed")
+        }
+   }
+
+   //==== Delete =============================================
+
+    func deleteHabit(_ habit: Habit) async {
+          do {
+                try await habitService.deleteHabit(habit)
+                habits.removeAll { $0.id == habit.id }
+          } catch {
+                errorMessage = String(localized: "error_save_failed")
+          }
+    }
+
+    //==== Check In =============================================
+
+    func checkIn(_ habit: Habit) async {
+        guard !habit.isCompletedToday else { return }
+
+        do {
+            try await habitService.checkIn(habit, on: Date())
+            if let index = habits.firstIndex(where: { $0.id == habit.id }) {
+                habits[index].completedDates.append(Date())
+            }
+        } catch {
+            errorMessage = String(localized: "error_save_failed")
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Implemented the full habit service layer and view model following the same architecture patterns as the auth layer.

## Changes
- Added `HabitServiceProtocol.swift` in `Services/Habit/`
- Removed `.gitkeep` from `Services/Habit/`
- Added `HabitService.swift` with Firestore CRUD and check-in logic
- Implemented `HabitViewModel.swift` with fetch, add, delete and check-in logic

## Why
- `HabitServiceProtocol` defines the contract and keeps `HabitViewModel` Firebase-agnostic
- `HabitService` handles all Firestore communication and `Timestamp` conversion via Codable
- `HabitViewModel` exposes state to views with no Firebase knowledge
- Follows the same protocol-driven, single responsibility pattern as the auth layer

## Result
Habits can now be fetched, created, deleted and checked in against Firestore. Ready to wire up to views.