### PR TITLE
refactor: marked AuthViewModel as final class

### DIFF
--- a/Nudge/ViewModels/AuthViewModel.swift
+++ b/Nudge/ViewModels/AuthViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import FirebaseAuth
 
 @Observable
-class AuthViewModel {
+final class AuthViewModel {
 
     //==== State =============================================
 


### PR DESCRIPTION
## Summary
Minor consistency fix to match the same pattern as HabitViewModel.

## Changes
- Updated `AuthViewModel.swift` — `class` → `final class`

## Why
- `@Observable` ViewModels are never subclassed
- Consistent with `HabitViewModel`
- Allows the compiler to optimize method dispatch

## Result
Both ViewModels follow the same conventions.