### PR TITLE
feat: added sign out button to ProfileView hero card

### DIFF
--- a/Nudge/Views/Profile/ProfileView.swift
+++ b/Nudge/Views/Profile/ProfileView.swift
@@ -96,6 +96,16 @@ struct ProfileView: View {
             }
 
             Spacer()
+
+            Button {
+                authVM.signOut()
+            } label: {
+                Image(systemName: "rectangle.portrait.and.arrow.right")
+                    .font(.system(size: IconSize.md))
+                    .foregroundStyle(Theme.nudgeTextMuted)
+            }
+
+
         }
         .padding(Spacing.lg)
         .background(Theme.nudgeCard)


### PR DESCRIPTION
## Summary
Added a sign out button to the ProfileView hero card.

## Changes
- Updated `ProfileView.swift` — added sign out button to `heroCard`

## Why
- Sign out is a G-krav (#16) that was implemented in `AuthViewModel` but had no UI entry point
- Placed in the hero card as a discrete icon to the right, keeping it accessible but not distracting

## Result
User can now sign out from the app via the profile screen.