### PR TITLE
feat: set displayName in Firebase Auth on sign up

### DIFF
--- a/Nudge/Services/Auth/AuthService.swift
+++ b/Nudge/Services/Auth/AuthService.swift
@@ -8,10 +8,13 @@ final class AuthService: AuthServiceProtocol {
         return result.user
     }
 
-    func signUp(email: String, password: String) async throws -> User {
+    func signUp(email: String, password: String, name: String) async throws -> User {
         let result = try await Auth.auth().createUser(withEmail: email, password: password)
+        let changeRequest = result.user.createProfileChangeRequest()
+        changeRequest.displayName = name
+        try await changeRequest.commitChanges()
         return result.user
-    }
+    }   
 
     func signOut() throws {
         try Auth.auth().signOut()

--- a/Nudge/Services/Auth/AuthServiceProtocol.swift
+++ b/Nudge/Services/Auth/AuthServiceProtocol.swift
@@ -10,7 +10,7 @@ import FirebaseAuth
 
 protocol AuthServiceProtocol {
     func signIn(email: String, password: String) async throws -> User
-    func signUp(email: String, password: String) async throws -> User
+    func signUp(email: String, password: String, name: String) async throws -> User
     func signOut() throws
     func addStateDidChangeListener(_ listener: @escaping (User?) -> Void) -> AuthStateDidChangeListenerHandle
 }

--- a/Nudge/ViewModels/AuthViewModel.swift
+++ b/Nudge/ViewModels/AuthViewModel.swift
@@ -58,7 +58,7 @@ final class AuthViewModel {
         errorMessage = nil
 
         do {
-            _ = try await authService.signUp(email: email, password: password)
+            _ = try await authService.signUp(email: email, password: password, name: name)
         } catch {
             errorMessage = String(localized: "error_save_failed")
         }

--- a/Nudge/Views/Auth/SignUpView.swift
+++ b/Nudge/Views/Auth/SignUpView.swift
@@ -80,7 +80,7 @@ struct SignUpView: View {
                 VStack(spacing: Spacing.md) {
                     Button {
                         Task {
-                            await vm.signUp(email: email, password: password)
+                            await vm.signUp(email: email, password: password, name: name)
                         }
                     } label: {
                         Group {

--- a/Nudge/Views/Profile/ProfileView.swift
+++ b/Nudge/Views/Profile/ProfileView.swift
@@ -82,7 +82,7 @@ struct ProfileView: View {
                     .foregroundStyle(Theme.nudgeTextMuted)
                 
                 HStack(spacing: Spacing.xs) {
-                    Image(systemName: "zap.fill")
+                    Image(systemName: "bolt.fill")
                         .font(.system(size: IconSize.sm))
                     Text("\(habitVM.totalCheckIns) \(String(localized: "profile_checkins_total"))")
                         .font(.system(size: FontSize.xs, weight: .semibold))


### PR DESCRIPTION
## Summary
Updated the sign up flow to set displayName in Firebase Auth when a new account is created.

## Changes
- Updated `AuthServiceProtocol.swift` — added `name` parameter to `signUp`
- Updated `AuthService.swift` — sets `displayName` via `createProfileChangeRequest` after account creation
- Updated `AuthViewModel.swift` — passes `name` to `signUp`
- Updated `SignUpView.swift` — passes `name` field to `authVM.signUp`
- Fixed `ProfileView.swift` — replaced `zap.fill` with `bolt.fill` to match SF Symbols naming

## Why
- New users had no `displayName` set in Firebase Auth, causing the hero card to show "N" as fallback
- `createProfileChangeRequest` is the correct Firebase Auth API for setting display name after account creation

## Result
New accounts now have `displayName` set correctly — the hero card shows the user's initial and name immediately after sign up.