### PR TITLE
fix: added name parameter to signUp function signature in AuthViewModel

### DIFF
--- a/Nudge/ViewModels/AuthViewModel.swift
+++ b/Nudge/ViewModels/AuthViewModel.swift
@@ -53,7 +53,7 @@ final class AuthViewModel {
 
     //==== Sign Up =============================================
 
-    func signUp(email: String, password: String) async {
+    func signUp(email: String, password: String, name: String) async {
         isLoading = true
         errorMessage = nil
 


### PR DESCRIPTION
## Summary
Minor fix to complete the displayName implementation from the previous PR.

## Changes
- Updated `AuthViewModel.swift` — added `name` parameter to `signUp` function signature

## Why
- The `name` parameter was added to the `do` block but missed in the function signature
- Without this fix, the compiler would fail to match the call from `SignUpView`

## Result
`signUp` function signature in `AuthViewModel` now correctly matches `AuthServiceProtocol`.