### PR TITLE
fix: return Auth.auth().currentUser after reload to ensure updated displayName

### DIFF
--- a/Nudge/Services/Auth/AuthService.swift
+++ b/Nudge/Services/Auth/AuthService.swift
@@ -14,7 +14,7 @@ final class AuthService: AuthServiceProtocol {
         changeRequest.displayName = name
         try await changeRequest.commitChanges()
         try await result.user.reload()
-        return result.user
+        return Auth.auth().currentUser ?? result.user
     }   
 
     func signOut() throws {


### PR DESCRIPTION
## Summary
Fixed displayName still not appearing after sign up by returning the correct user object after reload.

## Changes
- Updated `AuthService.swift` — returns `Auth.auth().currentUser ?? result.user` instead of `result.user`

## Why
- `result.user` is the original user object created before `commitChanges` and `reload`
- `Auth.auth().currentUser` is the updated user object after `reload` with `displayName` set
- Returning `result.user` meant the listener received a stale object without `displayName`

## Result
displayName is now correctly returned after sign up and visible in the hero card immediately.