### PR TITLE
refactor: renamed AppNavigation to AppNavigationView

### DIFF
--- a/Nudge/NudgeApp.swift
+++ b/Nudge/NudgeApp.swift
@@ -23,7 +23,7 @@ struct NudgeApp: App {
 
     var body: some Scene {
         WindowGroup {
-            AppNavigation()
+            AppNavigationView()
                 .environment(authViewModel)
                 .environment(habitViewModel)
                 .environment(statsViewModel)

--- a/Nudge/Views/AppNavigationView.swift
+++ b/Nudge/Views/AppNavigationView.swift
@@ -1,5 +1,5 @@
 //
-//  AppNavigation.swift
+//  AppNavigationView.swift
 //  Nudge
 //
 //  Created by Linnéa on 2026-05-04.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct AppNavigation: View {
+struct AppNavigationView: View {
 
     @Environment(AuthViewModel.self) private var authVM
     @State private var selectedTab: Tab = .profile


### PR DESCRIPTION
## Summary
Renames AppNavigation to AppNavigationView to follow the consistent View suffix convention established across the codebase.

## Changes
- Renamed `AppNavigation` → `AppNavigationView` in `AppNavigation.swift`
- Updated reference in `NudgeApp.swift`

## Why
- Every struct conforming to View should have a View suffix
- Missed in previous rename branch

## Result
All SwiftUI structs now consistently follow the View suffix convention.