### PR TITLE
feat: habit categories

### DIFF
--- a/Nudge/Core/Localizable.xcstrings
+++ b/Nudge/Core/Localizable.xcstrings
@@ -248,6 +248,17 @@
         }
       }
     },
+    "habits_change_icon" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Change icon"
+          }
+        }
+      }
+    },
     "habits_choose_category" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Nudge/Core/Localizable.xcstrings
+++ b/Nudge/Core/Localizable.xcstrings
@@ -248,6 +248,17 @@
         }
       }
     },
+    "habits_choose_category" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose a category"
+          }
+        }
+      }
+    },
     "habits_choose_icon" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Nudge/Core/Presets.swift
+++ b/Nudge/Core/Presets.swift
@@ -52,3 +52,13 @@ enum Symbols {
         "pawprint", "ant", "tortoise"
     ]
 }
+
+
+enum Categories {
+    static let habitCategories = [
+        "Fitness",
+        "Health",
+        "Mindfulness",
+        "Hobbies"
+    ]
+}

--- a/Nudge/Models/Habit.swift
+++ b/Nudge/Models/Habit.swift
@@ -13,6 +13,7 @@ struct Habit: Identifiable, Codable {
     let userId: String
     var name: String
     var icon: String
+    var category: String
     var completedDates: [Date]
     var createdAt: Date
 }

--- a/Nudge/ViewModels/HabitViewModel.swift
+++ b/Nudge/ViewModels/HabitViewModel.swift
@@ -44,6 +44,10 @@ final class HabitViewModel {
         ]
         return messages[totalCheckIns % messages.count]
     }
+    
+    var habitsByCategory: [String: [Habit]] {
+           Dictionary(grouping: habits, by: { $0.category })
+    }
 
     //==== Fetch =============================================
 
@@ -62,7 +66,7 @@ final class HabitViewModel {
    
    //==== Add =======================================
 
-   func addHabit(name: String, icon: String, userId: String) async {
+    func addHabit(name: String, icon: String, category: String, userId: String) async {
         guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
             errorMessage = String(localized: "error_empty_name")
             return
@@ -73,6 +77,7 @@ final class HabitViewModel {
             userId: userId,
             name: name,
             icon: icon,
+            category: category,
             completedDates: [],
             createdAt: Date()
         )

--- a/Nudge/Views/Components/CategoryPickerView.swift
+++ b/Nudge/Views/Components/CategoryPickerView.swift
@@ -10,29 +10,57 @@ import SwiftUI
 struct CategoryPickerView: View {
 
     @Binding var selectedCategory: String
+    @State private var isExpanded = false
 
     var body: some View {
-        Menu {
-            ForEach(Categories.habitCategories, id: \.self) { category in
-                Button(category) {
-                    selectedCategory = category
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Button {
+                withAnimation {
+                    isExpanded.toggle()
+                }
+            } label: {
+                PrimaryCardView {
+                    HStack {
+                        Text(selectedCategory.isEmpty
+                             ? String(localized: "habits_choose_category")
+                             : selectedCategory
+                        )
+                        .font(.system(size: FontSize.md))
+                        .foregroundStyle(selectedCategory.isEmpty ? Theme.nudgeTextMuted : Theme.nudgeTextPrimary)
+
+                        Spacer()
+
+                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                            .font(.system(size: FontSize.sm))
+                            .foregroundStyle(Theme.nudgeTextMuted)
+                    }
                 }
             }
-        } label: {
-            PrimaryCardView {
-                HStack {
-                    Text(selectedCategory.isEmpty
-                         ? String(localized: "habits_choose_category")
-                         : selectedCategory
-                    )
-                    .font(.system(size: FontSize.md))
-                    .foregroundStyle(selectedCategory.isEmpty ? Theme.nudgeTextMuted : Theme.nudgeTextPrimary)
 
-                    Spacer()
-
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: FontSize.sm))
-                        .foregroundStyle(Theme.nudgeTextMuted)
+            if isExpanded {
+                PrimaryCardView {
+                    VStack(spacing: Spacing.xs) {
+                        ForEach(Categories.habitCategories, id: \.self) { category in
+                            Button {
+                                selectedCategory = category
+                                withAnimation {
+                                    isExpanded = false
+                                }
+                            } label: {
+                                HStack {
+                                    Text(category)
+                                        .font(.system(size: FontSize.md))
+                                        .foregroundStyle(selectedCategory == category ? Theme.nudgeTextPrimary : Theme.nudgeTextMuted)
+                                    Spacer()
+                                    if selectedCategory == category {
+                                        Image(systemName: "checkmark")
+                                            .font(.system(size: FontSize.sm))
+                                            .foregroundStyle(Theme.nudgeSuccess)
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/Nudge/Views/Components/CategoryPickerView.swift
+++ b/Nudge/Views/Components/CategoryPickerView.swift
@@ -1,0 +1,27 @@
+//
+//  CategoryPickerView.swift
+//  Nudge
+//
+//  Created by Linnéa on 2026-05-06.
+//
+
+import SwiftUI
+
+struct CategoryPickerView: View {
+
+    @Binding var selectedCategory: String
+
+    var body: some View {
+        Picker(String(localized: "habits_choose_category"), selection: $selectedCategory) {
+            ForEach(Categories.habitCategories, id: \.self) { category in
+                Text(category).tag(category)
+            }
+        }
+        .pickerStyle(.menu)
+        .tint(Theme.nudgeAccentLight)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Spacing.md)
+        .background(Theme.nudgeCard)
+        .clipShape(RoundedRectangle(cornerRadius: Radius.lg))
+    }
+}

--- a/Nudge/Views/Components/CategoryPickerView.swift
+++ b/Nudge/Views/Components/CategoryPickerView.swift
@@ -12,16 +12,29 @@ struct CategoryPickerView: View {
     @Binding var selectedCategory: String
 
     var body: some View {
-        Picker(String(localized: "habits_choose_category"), selection: $selectedCategory) {
+        Menu {
             ForEach(Categories.habitCategories, id: \.self) { category in
-                Text(category).tag(category)
+                Button(category) {
+                    selectedCategory = category
+                }
+            }
+        } label: {
+            PrimaryCardView {
+                HStack {
+                    Text(selectedCategory.isEmpty
+                         ? String(localized: "habits_choose_category")
+                         : selectedCategory
+                    )
+                    .font(.system(size: FontSize.md))
+                    .foregroundStyle(selectedCategory.isEmpty ? Theme.nudgeTextMuted : Theme.nudgeTextPrimary)
+
+                    Spacer()
+
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: FontSize.sm))
+                        .foregroundStyle(Theme.nudgeTextMuted)
+                }
             }
         }
-        .pickerStyle(.menu)
-        .tint(Theme.nudgeAccentLight)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(Spacing.md)
-        .background(Theme.nudgeCard)
-        .clipShape(RoundedRectangle(cornerRadius: Radius.lg))
     }
 }

--- a/Nudge/Views/Components/CategoryPickerView.swift
+++ b/Nudge/Views/Components/CategoryPickerView.swift
@@ -14,26 +14,14 @@ struct CategoryPickerView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
-            Button {
+            PickerHeaderView(
+                label: selectedCategory.isEmpty
+                    ? String(localized: "habits_choose_category")
+                    : selectedCategory,
+                isExpanded: isExpanded
+            ) {
                 withAnimation {
                     isExpanded.toggle()
-                }
-            } label: {
-                PrimaryCardView {
-                    HStack {
-                        Text(selectedCategory.isEmpty
-                             ? String(localized: "habits_choose_category")
-                             : selectedCategory
-                        )
-                        .font(.system(size: FontSize.md))
-                        .foregroundStyle(selectedCategory.isEmpty ? Theme.nudgeTextMuted : Theme.nudgeTextPrimary)
-
-                        Spacer()
-
-                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                            .font(.system(size: FontSize.sm))
-                            .foregroundStyle(Theme.nudgeTextMuted)
-                    }
                 }
             }
 

--- a/Nudge/Views/Components/IconPickerView.swift
+++ b/Nudge/Views/Components/IconPickerView.swift
@@ -5,32 +5,63 @@
 //  Created by Linnéa on 2026-05-06.
 //
 
+
 import SwiftUI
 
 struct IconPickerView: View {
 
     @Binding var selectedIcon: String
+    @State private var isExpanded = false
 
     private let columns = Array(repeating: GridItem(.flexible()), count: 4)
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
-            Text(String(localized: "habits_choose_icon"))
-                .font(.system(size: FontSize.sm))
-                .foregroundStyle(Theme.nudgeTextMuted)
+            Button {
+                withAnimation {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack {
+                    if selectedIcon.isEmpty {
+                        Text(String(localized: "habits_choose_icon"))
+                            .font(.system(size: FontSize.md))
+                            .foregroundStyle(Theme.nudgeTextMuted)
+                    } else {
+                        Image(systemName: selectedIcon)
+                            .font(.system(size: IconSize.md))
+                            .foregroundStyle(Theme.nudgeAccentLight)
+                        Text(String(localized: "habits_choose_icon"))
+                            .font(.system(size: FontSize.md))
+                            .foregroundStyle(Theme.nudgeTextMuted)
+                    }
+                    Spacer()
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: FontSize.sm))
+                        .foregroundStyle(Theme.nudgeTextMuted)
+                }
+                .padding(Spacing.md)
+                .background(Theme.nudgeCard)
+                .clipShape(RoundedRectangle(cornerRadius: Radius.lg))
+            }
 
-            LazyVGrid(columns: columns, spacing: Spacing.sm) {
-                ForEach(Symbols.habitIcons, id: \.self) { icon in
-                    Button {
-                        selectedIcon = icon
-                    } label: {
-                        Image(systemName: icon)
-                            .font(.system(size: IconSize.lg))
-                            .foregroundStyle(selectedIcon == icon ? Theme.nudgeTextPrimary : Theme.nudgeTextMuted)
-                            .frame(maxWidth: .infinity)
-                            .padding(Spacing.sm)
-                            .background(selectedIcon == icon ? Theme.nudgeAccent : Theme.nudgeCard)
-                            .clipShape(RoundedRectangle(cornerRadius: Radius.sm))
+            if isExpanded {
+                LazyVGrid(columns: columns, spacing: Spacing.sm) {
+                    ForEach(Symbols.habitIcons, id: \.self) { icon in
+                        Button {
+                            selectedIcon = icon
+                            withAnimation {
+                                isExpanded = false
+                            }
+                        } label: {
+                            Image(systemName: icon)
+                                .font(.system(size: IconSize.lg))
+                                .foregroundStyle(selectedIcon == icon ? Theme.nudgeTextPrimary : Theme.nudgeTextMuted)
+                                .frame(maxWidth: .infinity)
+                                .padding(Spacing.sm)
+                                .background(selectedIcon == icon ? Theme.nudgeAccent : Theme.nudgeCard)
+                                .clipShape(RoundedRectangle(cornerRadius: Radius.sm))
+                        }
                     }
                 }
             }

--- a/Nudge/Views/Components/IconPickerView.swift
+++ b/Nudge/Views/Components/IconPickerView.swift
@@ -2,9 +2,8 @@
 //  IconPickerView.swift
 //  Nudge
 //
-//  Created by Linnéa on 2026-05-06.
+//  Created by Linnéa on 2026-04-28.
 //
-
 
 import SwiftUI
 
@@ -22,28 +21,27 @@ struct IconPickerView: View {
                     isExpanded.toggle()
                 }
             } label: {
-                HStack {
-                    if !selectedIcon.isEmpty {
-                        Image(systemName: selectedIcon)
-                            .font(.system(size: IconSize.md))
-                            .foregroundStyle(Theme.nudgeAccentLight)
+                PrimaryCardView {
+                    HStack {
+                        if !selectedIcon.isEmpty {
+                            Image(systemName: selectedIcon)
+                                .font(.system(size: IconSize.md))
+                                .foregroundStyle(Theme.nudgeAccentLight)
+                        }
+                        Text(selectedIcon.isEmpty
+                             ? String(localized: "habits_choose_icon")
+                             : String(localized: "habits_change_icon")
+                        )
+                        .font(.system(size: FontSize.md))
+                        .foregroundStyle(selectedIcon.isEmpty ? Theme.nudgeTextMuted : Theme.nudgeTextPrimary)
+
+                        Spacer()
+
+                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                            .font(.system(size: FontSize.sm))
+                            .foregroundStyle(Theme.nudgeTextMuted)
                     }
-                    Text(selectedIcon.isEmpty
-                         ? String(localized: "habits_choose_icon")
-                         : String(localized: "habits_change_icon")
-                    )
-                    .font(.system(size: FontSize.md))
-                    .foregroundStyle(selectedIcon.isEmpty ? Theme.nudgeTextMuted : Theme.nudgeTextPrimary)
-
-                    Spacer()
-
-                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                        .font(.system(size: FontSize.sm))
-                        .foregroundStyle(Theme.nudgeTextMuted)
                 }
-                .padding(Spacing.md)
-                .background(Theme.nudgeCard)
-                .clipShape(RoundedRectangle(cornerRadius: Radius.lg))
             }
 
             if isExpanded {

--- a/Nudge/Views/Components/IconPickerView.swift
+++ b/Nudge/Views/Components/IconPickerView.swift
@@ -20,7 +20,8 @@ struct IconPickerView: View {
                 label: selectedIcon.isEmpty
                     ? String(localized: "habits_choose_icon")
                     : String(localized: "habits_change_icon"),
-                isExpanded: isExpanded
+                isExpanded: isExpanded,
+                leadingIcon: selectedIcon.isEmpty ? nil : selectedIcon
             ) {
                 withAnimation {
                     isExpanded.toggle()

--- a/Nudge/Views/Components/IconPickerView.swift
+++ b/Nudge/Views/Components/IconPickerView.swift
@@ -16,31 +16,14 @@ struct IconPickerView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
-            Button {
+            PickerHeaderView(
+                label: selectedIcon.isEmpty
+                    ? String(localized: "habits_choose_icon")
+                    : String(localized: "habits_change_icon"),
+                isExpanded: isExpanded
+            ) {
                 withAnimation {
                     isExpanded.toggle()
-                }
-            } label: {
-                PrimaryCardView {
-                    HStack {
-                        if !selectedIcon.isEmpty {
-                            Image(systemName: selectedIcon)
-                                .font(.system(size: IconSize.md))
-                                .foregroundStyle(Theme.nudgeAccentLight)
-                        }
-                        Text(selectedIcon.isEmpty
-                             ? String(localized: "habits_choose_icon")
-                             : String(localized: "habits_change_icon")
-                        )
-                        .font(.system(size: FontSize.md))
-                        .foregroundStyle(selectedIcon.isEmpty ? Theme.nudgeTextMuted : Theme.nudgeTextPrimary)
-
-                        Spacer()
-
-                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                            .font(.system(size: FontSize.sm))
-                            .foregroundStyle(Theme.nudgeTextMuted)
-                    }
                 }
             }
 

--- a/Nudge/Views/Components/IconPickerView.swift
+++ b/Nudge/Views/Components/IconPickerView.swift
@@ -23,19 +23,20 @@ struct IconPickerView: View {
                 }
             } label: {
                 HStack {
-                    if selectedIcon.isEmpty {
-                        Text(String(localized: "habits_choose_icon"))
-                            .font(.system(size: FontSize.md))
-                            .foregroundStyle(Theme.nudgeTextMuted)
-                    } else {
+                    if !selectedIcon.isEmpty {
                         Image(systemName: selectedIcon)
                             .font(.system(size: IconSize.md))
                             .foregroundStyle(Theme.nudgeAccentLight)
-                        Text(String(localized: "habits_choose_icon"))
-                            .font(.system(size: FontSize.md))
-                            .foregroundStyle(Theme.nudgeTextMuted)
                     }
+                    Text(selectedIcon.isEmpty
+                         ? String(localized: "habits_choose_icon")
+                         : String(localized: "habits_change_icon")
+                    )
+                    .font(.system(size: FontSize.md))
+                    .foregroundStyle(selectedIcon.isEmpty ? Theme.nudgeTextMuted : Theme.nudgeTextPrimary)
+
                     Spacer()
+
                     Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                         .font(.system(size: FontSize.sm))
                         .foregroundStyle(Theme.nudgeTextMuted)

--- a/Nudge/Views/Components/PickerHeaderView.swift
+++ b/Nudge/Views/Components/PickerHeaderView.swift
@@ -11,12 +11,18 @@ struct PickerHeaderView: View {
 
     let label: String
     let isExpanded: Bool
+    var leadingIcon: String? = nil
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
             PrimaryCardView {
                 HStack {
+                    if let leadingIcon {
+                        Image(systemName: leadingIcon)
+                            .font(.system(size: IconSize.md))
+                            .foregroundStyle(Theme.nudgeAccentLight)
+                    }
                     Text(label)
                         .font(.system(size: FontSize.md))
                         .foregroundStyle(Theme.nudgeTextMuted)

--- a/Nudge/Views/Components/PickerHeaderView.swift
+++ b/Nudge/Views/Components/PickerHeaderView.swift
@@ -1,0 +1,31 @@
+//
+//  PickerHeaderView.swift
+//  Nudge
+//
+//  Created by Linnéa on 2026-05-06.
+//
+
+import SwiftUI
+
+struct PickerHeaderView: View {
+
+    let label: String
+    let isExpanded: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            PrimaryCardView {
+                HStack {
+                    Text(label)
+                        .font(.system(size: FontSize.md))
+                        .foregroundStyle(Theme.nudgeTextMuted)
+                    Spacer()
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: FontSize.sm))
+                        .foregroundStyle(Theme.nudgeTextMuted)
+                }
+            }
+        }
+    }
+}

--- a/Nudge/Views/Habits/AddHabitView.swift
+++ b/Nudge/Views/Habits/AddHabitView.swift
@@ -19,11 +19,14 @@ struct AddHabitView: View {
 
     @State private var name = ""
     @State private var selectedIcon = ""
+    @State private var selectedCategory = ""
 
     //==== Computed =============================================
 
     private var isFormValid: Bool {
-        !name.trimmingCharacters(in: .whitespaces).isEmpty && !selectedIcon.isEmpty
+        !name.trimmingCharacters(in: .whitespaces).isEmpty &&
+        !selectedIcon.isEmpty &&
+        !selectedCategory.isEmpty
     }
 
     //==== Body =============================================
@@ -44,6 +47,8 @@ struct AddHabitView: View {
 
                         NameFieldView(text: $name)
 
+                        CategoryPickerView(selectedCategory: $selectedCategory)
+
                         IconPickerView(selectedIcon: $selectedIcon)
                     }
                     .padding(Spacing.lg)
@@ -58,6 +63,7 @@ struct AddHabitView: View {
                         await habitVM.addHabit(
                             name: name,
                             icon: selectedIcon,
+                            category: selectedCategory,
                             userId: userId
                         )
                         if habitVM.errorMessage == nil {

--- a/Nudge/Views/Habits/HabitsView.swift
+++ b/Nudge/Views/Habits/HabitsView.swift
@@ -37,11 +37,20 @@ struct HabitsView: View {
                             subtitle: String(localized: "habits_subtitle")
                         )
 
-                        VStack(spacing: Spacing.sm) {
-                            ForEach(habitVM.habits) { habit in
-                                HabitRowView(habit: habit, onCheckIn: {}) {
-                                    Task {
-                                        await habitVM.deleteHabit(habit)
+                        ForEach(Categories.habitCategories, id: \.self) { category in
+                            let habits = habitVM.habitsByCategory[category] ?? []
+                            if !habits.isEmpty {
+                                VStack(alignment: .leading, spacing: Spacing.sm) {
+                                    Text(category)
+                                        .font(.system(size: FontSize.md, weight: .semibold))
+                                        .foregroundStyle(Theme.nudgeTextMuted)
+
+                                    ForEach(habits) { habit in
+                                        HabitRowView(habit: habit, onCheckIn: {}) {
+                                            Task {
+                                                await habitVM.deleteHabit(habit)
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/Nudge/Views/Profile/ProfileView.swift
+++ b/Nudge/Views/Profile/ProfileView.swift
@@ -37,17 +37,20 @@ struct ProfileView: View {
 
                         MotivationView(motivationMessage: habitVM.motivationMessage)
 
-                        PrimaryHeaderView(
-                            title: String(localized: "profile_today"),
-                            trailingText: "\(habitVM.completedToday) / \(habitVM.habits.count) \(String(localized: "profile_done"))",
-                            trailingColor: Theme.nudgeSuccess
-                        )
+                        ForEach(Categories.habitCategories, id: \.self) { category in
+                            let habits = habitVM.habitsByCategory[category] ?? []
+                            if !habits.isEmpty {
+                                VStack(alignment: .leading, spacing: Spacing.sm) {
+                                    Text(category)
+                                        .font(.system(size: FontSize.md, weight: .semibold))
+                                        .foregroundStyle(Theme.nudgeTextMuted)
 
-                        VStack(spacing: Spacing.sm) {
-                            ForEach(habitVM.habits) { habit in
-                                HabitRowView(habit: habit) {
-                                    Task {
-                                        await habitVM.checkIn(habit)
+                                    ForEach(habits) { habit in
+                                        HabitRowView(habit: habit) {
+                                            Task {
+                                                await habitVM.checkIn(habit)
+                                            }
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
Adds category support to habits, allowing users to organize their habits into predefined categories displayed as grouped lists in ProfileView and HabitsView.

## Changes
- Added `category` field to `Habit` model
- Added `habitsByCategory` computed property and `category` param to `addHabit` in `HabitViewModel`
- Renamed `Symbols.swift` to `Presets.swift` and added `Categories` enum alongside `Symbols` enum with four categories: Fitness, Health, Mindfulness, Hobbies
- Added `CategoryPickerView` to Components
- Added `PickerHeaderView` to Components as shared picker header for both pickers
- Updated `IconPickerView` to use `PickerHeaderView` and show selected icon
- Updated `AddHabitView` with `CategoryPickerView` and updated `addHabit` call
- Updated `HabitsView` to display habits grouped by category
- Updated `ProfileView` to display habits grouped by category

## Why
- A flat list is overwhelming for NPF users — categories give structure without complexity
- Four predefined categories keep it simple and consistent
- Same grouped layout in both ProfileView and HabitsView for consistency

## Result
Users can assign a category when creating a habit. Habits are displayed in grouped lists under their category in both Profile and Habits screens.