### PR TITLE
feat: edit habit

### DIFF
--- a/Nudge/Core/Localizable.xcstrings
+++ b/Nudge/Core/Localizable.xcstrings
@@ -292,6 +292,17 @@
         }
       }
     },
+    "habits_edit_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit habit"
+          }
+        }
+      }
+    },
     "habits_name_placeholder" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -310,6 +321,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Save habit"
+          }
+        }
+      }
+    },
+    "habits_save_changes" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save changes"
           }
         }
       }

--- a/Nudge/Services/Habit/HabitService.swift
+++ b/Nudge/Services/Habit/HabitService.swift
@@ -34,6 +34,14 @@ final class HabitService: HabitServiceProtocol {
             .document(habit.id)
             .setData(from: habit)
     }
+    
+    //==== Update =============================================
+
+    func updateHabit(_ habit: Habit) async throws {
+        try db.collection(collection)
+            .document(habit.id)
+            .setData(from: habit, merge: true)
+    }
 
     //==== Delete =============================================
 

--- a/Nudge/Services/Habit/HabitServiceProtocol.swift
+++ b/Nudge/Services/Habit/HabitServiceProtocol.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol HabitServiceProtocol {
     func fetchHabits(for userId: String) async throws -> [Habit]
     func addHabit(_ habit: Habit) async throws
+    func updateHabit(_ habit: Habit) async throws
     func deleteHabit(_ habit: Habit) async throws
     func checkIn(_ habit: Habit, on date: Date) async throws
 }

--- a/Nudge/ViewModels/HabitViewModel.swift
+++ b/Nudge/ViewModels/HabitViewModel.swift
@@ -89,6 +89,19 @@ final class HabitViewModel {
             errorMessage = String(localized: "error_save_failed")
         }
    }
+    
+    //==== Update =============================================
+
+    func updateHabit(_ habit: Habit) async {
+        do {
+            try await habitService.updateHabit(habit)
+            if let index = habits.firstIndex(where: { $0.id == habit.id }) {
+                habits[index] = habit
+            }
+        } catch {
+            errorMessage = String(localized: "error_save_failed")
+        }
+    }
 
    //==== Delete =============================================
 

--- a/Nudge/Views/Components/HabitRowView.swift
+++ b/Nudge/Views/Components/HabitRowView.swift
@@ -12,8 +12,7 @@ struct HabitRowView: View {
     //==== Properties =============================================
 
     let habit: Habit
-    let onCheckIn: () -> Void
-    var onDelete: (() -> Void)? = nil
+    var onCheckIn: (() -> Void)? = nil
 
     //==== Body =============================================
 
@@ -44,13 +43,7 @@ struct HabitRowView: View {
 
                 //==== Action Button =============================================
 
-                if let onDelete {
-                    Button(action: onDelete) {
-                        Image(systemName: "trash")
-                            .font(.system(size: IconSize.md))
-                            .foregroundStyle(Theme.nudgeTextMuted)
-                    }
-                } else {
+                if let onCheckIn {
                     Button(action: onCheckIn) {
                         ZStack {
                             Circle()

--- a/Nudge/Views/Habits/HabitFormView.swift
+++ b/Nudge/Views/Habits/HabitFormView.swift
@@ -1,5 +1,5 @@
 //
-//  AddHabitView.swift
+//  HabitFormView.swift
 //  Nudge
 //
 //  Created by Linnéa on 2026-04-28.
@@ -7,7 +7,11 @@
 
 import SwiftUI
 
-struct AddHabitView: View {
+struct HabitFormView: View {
+
+    //==== Properties =============================================
+
+    var habit: Habit? = nil
 
     //==== Environment =============================================
 
@@ -22,6 +26,8 @@ struct AddHabitView: View {
     @State private var selectedCategory = ""
 
     //==== Computed =============================================
+
+    private var isEditing: Bool { habit != nil }
 
     private var isFormValid: Bool {
         !name.trimmingCharacters(in: .whitespaces).isEmpty &&
@@ -40,7 +46,7 @@ struct AddHabitView: View {
                 ScrollView {
                     VStack(spacing: Spacing.lg) {
                         PrimaryHeaderView(
-                            title: String(localized: "habits_title"),
+                            title: String(localized: isEditing ? "habits_edit_title" : "habits_title"),
                             subtitle: String(localized: "habits_add_placeholder"),
                             onDismiss: { dismiss() }
                         )
@@ -55,23 +61,38 @@ struct AddHabitView: View {
                 }
 
                 PrimaryButtonView(
-                    label: String(localized: "habits_save"),
+                    label: String(localized: isEditing ? "habits_save_changes" : "habits_save"),
                     isDisabled: !isFormValid
                 ) {
                     Task {
-                        guard let userId = authVM.userId else { return }
-                        await habitVM.addHabit(
-                            name: name,
-                            icon: selectedIcon,
-                            category: selectedCategory,
-                            userId: userId
-                        )
+                        if isEditing {
+                            guard var updatedHabit = habit else { return }
+                            updatedHabit.name = name
+                            updatedHabit.icon = selectedIcon
+                            updatedHabit.category = selectedCategory
+                            await habitVM.updateHabit(updatedHabit)
+                        } else {
+                            guard let userId = authVM.userId else { return }
+                            await habitVM.addHabit(
+                                name: name,
+                                icon: selectedIcon,
+                                category: selectedCategory,
+                                userId: userId
+                            )
+                        }
                         if habitVM.errorMessage == nil {
                             dismiss()
                         }
                     }
                 }
                 .padding(Spacing.lg)
+            }
+        }
+        .onAppear {
+            if let habit {
+                name = habit.name
+                selectedIcon = habit.icon
+                selectedCategory = habit.category
             }
         }
         .alert(

--- a/Nudge/Views/Habits/HabitsView.swift
+++ b/Nudge/Views/Habits/HabitsView.swift
@@ -31,51 +31,69 @@ struct HabitsView: View {
                 .ignoresSafeArea()
 
             VStack(spacing: Spacing.none) {
-                ScrollView {
-                    VStack(spacing: Spacing.lg) {
-                        PrimaryHeaderView(
-                            title: String(localized: "habits_title"),
-                            subtitle: String(localized: "habits_subtitle")
-                        )
+                VStack(spacing: Spacing.lg) {
+                    PrimaryHeaderView(
+                        title: String(localized: "habits_title"),
+                        subtitle: String(localized: "habits_subtitle")
+                    )
+                }
+                .padding(Spacing.lg)
 
-                        ForEach(Categories.habitCategories, id: \.self) { category in
-                            let habits = habitVM.habitsByCategory[category] ?? []
-                            if !habits.isEmpty {
-                                VStack(alignment: .leading, spacing: Spacing.sm) {
-                                    Text(category)
-                                        .font(.system(size: FontSize.md, weight: .semibold))
-                                        .foregroundStyle(Theme.nudgeTextMuted)
-
-                                    ForEach(habits) { habit in
-                                        HabitRowView(habit: habit)
-                                            .swipeActions(edge: .trailing) {
-                                                Button(role: .destructive) {
-                                                    Task {
-                                                        await habitVM.deleteHabit(habit)
-                                                    }
-                                                } label: {
-                                                    Image(systemName: "trash")
+                List {
+                    ForEach(Categories.habitCategories, id: \.self) { category in
+                        let habits = habitVM.habitsByCategory[category] ?? []
+                        if !habits.isEmpty {
+                            Section {
+                                ForEach(habits) { habit in
+                                    HabitRowView(habit: habit)
+                                        .swipeActions(edge: .trailing) {
+                                            Button(role: .destructive) {
+                                                Task {
+                                                    await habitVM.deleteHabit(habit)
                                                 }
+                                            } label: {
+                                                Image(systemName: "trash")
                                             }
-                                            .swipeActions(edge: .leading) {
-                                                Button {
-                                                    habitToEdit = habit
-                                                } label: {
-                                                    Image(systemName: "pencil")
-                                                }
-                                                .tint(Theme.nudgeAccent)
+                                        }
+                                        .swipeActions(edge: .leading) {
+                                            Button {
+                                                habitToEdit = habit
+                                            } label: {
+                                                Image(systemName: "pencil")
                                             }
-                                    }
+                                            .tint(Theme.nudgeAccent)
+                                        }
+                                        .listRowBackground(Color.clear)
+                                        .listRowSeparator(.hidden)
+                                        .listRowInsets(EdgeInsets(
+                                            top: Spacing.xs,
+                                            leading: Spacing.none,
+                                            bottom: Spacing.xs,
+                                            trailing: Spacing.none
+                                        ))
                                 }
+                            } header: {
+                                Text(category)
+                                    .font(.system(size: FontSize.md, weight: .semibold))
+                                    .foregroundStyle(Theme.nudgeTextMuted)
                             }
                         }
-
-                        AddHabitButtonView {
-                            showAddHabit = true
-                        }
                     }
-                    .padding(Spacing.lg)
+
+                    AddHabitButtonView {
+                        showAddHabit = true
+                    }
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(EdgeInsets(
+                        top: Spacing.xs,
+                        leading: Spacing.none,
+                        bottom: Spacing.xs,
+                        trailing: Spacing.none
+                    ))
                 }
+                .listStyle(.plain)
+                .scrollContentBackground(.hidden)
 
                 TabBarView(selectedTab: $selectedTab)
             }

--- a/Nudge/Views/Habits/HabitsView.swift
+++ b/Nudge/Views/Habits/HabitsView.swift
@@ -47,7 +47,7 @@ struct HabitsView: View {
                                         .foregroundStyle(Theme.nudgeTextMuted)
 
                                     ForEach(habits) { habit in
-                                        HabitRowView(habit: habit, onCheckIn: {})
+                                        HabitRowView(habit: habit)
                                             .swipeActions(edge: .trailing) {
                                                 Button(role: .destructive) {
                                                     Task {

--- a/Nudge/Views/Habits/HabitsView.swift
+++ b/Nudge/Views/Habits/HabitsView.swift
@@ -21,6 +21,7 @@ struct HabitsView: View {
     //==== State =============================================
 
     @State private var showAddHabit = false
+    @State private var habitToEdit: Habit? = nil
 
     //==== Body =============================================
 
@@ -46,11 +47,24 @@ struct HabitsView: View {
                                         .foregroundStyle(Theme.nudgeTextMuted)
 
                                     ForEach(habits) { habit in
-                                        HabitRowView(habit: habit, onCheckIn: {}) {
-                                            Task {
-                                                await habitVM.deleteHabit(habit)
+                                        HabitRowView(habit: habit, onCheckIn: {})
+                                            .swipeActions(edge: .trailing) {
+                                                Button(role: .destructive) {
+                                                    Task {
+                                                        await habitVM.deleteHabit(habit)
+                                                    }
+                                                } label: {
+                                                    Image(systemName: "trash")
+                                                }
                                             }
-                                        }
+                                            .swipeActions(edge: .leading) {
+                                                Button {
+                                                    habitToEdit = habit
+                                                } label: {
+                                                    Image(systemName: "pencil")
+                                                }
+                                                .tint(Theme.nudgeAccent)
+                                            }
                                     }
                                 }
                             }
@@ -67,7 +81,10 @@ struct HabitsView: View {
             }
         }
         .sheet(isPresented: $showAddHabit) {
-            AddHabitView()
+            HabitFormView()
+        }
+        .sheet(item: $habitToEdit) { habit in
+            HabitFormView(habit: habit)
         }
         .alert(
             String(localized: "error_title"),


### PR DESCRIPTION
## Summary
Adds the ability to edit existing habits and replaces the flat habit list with swipe-actions for delete and edit in HabitsView.

## Changes
- Added `updateHabit` to `HabitService`, `HabitServiceProtocol` and `HabitViewModel`
- Renamed `AddHabitView` to `HabitFormView` with add and edit mode based on optional `habit` parameter
- Fields pre-filled when editing, empty when adding
- Save button shows "Save changes" when editing, "Save habit" when adding
- Added `habits_save_changes` and `habits_edit_title` to Localizable
- Updated `HabitRowView` — made `onCheckIn` optional and removed `onDelete`
- Updated `HabitsView` with `List` and swipe-actions — swipe left to delete, swipe right to edit

## Why
- Users should be able to correct mistakes without deleting and recreating a habit
- NPF-friendly — no pressure to get it right the first time
- Swipe-actions is standard iOS pattern for list management

## Result
Users can swipe left to delete or swipe right to edit any habit. Edit opens a pre-filled form. Changes are saved to Firestore and reflected immediately in both HabitsView and ProfileView.