### PR TITLE
chore: polish header typography, weekly chart title and motivation strings

### DIFF
--- a/Nudge/Core/Constants.swift
+++ b/Nudge/Core/Constants.swift
@@ -48,6 +48,8 @@ enum FontSize {
 // ====== Icon Size ===============
 
 enum IconSize {
+    
+    static let xs: CGFloat = 14
     static let sm: CGFloat = 16
     static let md: CGFloat = 20
     static let lg: CGFloat = 24

--- a/Nudge/Core/Localizable.xcstrings
+++ b/Nudge/Core/Localizable.xcstrings
@@ -431,7 +431,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "You showed up yesterday. That counts."
+            "value" : "You showed up yesterday. That counts"
           }
         }
       }
@@ -442,7 +442,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "One small step is still a step."
+            "value" : "One small step is still a step"
           }
         }
       }
@@ -453,7 +453,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "You're doing better than you think."
+            "value" : "You're doing better than you think"
           }
         }
       }

--- a/Nudge/Views/Components/PrimaryHeaderView.swift
+++ b/Nudge/Views/Components/PrimaryHeaderView.swift
@@ -26,10 +26,10 @@ struct PrimaryHeaderView: View {
 
                 HStack(spacing: Spacing.xs) {
                     Text(subtitle)
-                        .font(.system(size: FontSize.sm))
+                        .font(.system(size: FontSize.md))
                         .foregroundStyle(Theme.nudgeAccentSoft)
                     Image(systemName: subtitleIcon)
-                        .font(.system(size: FontSize.xs))
+                        .font(.system(size: IconSize.xs))
                         .foregroundStyle(Theme.nudgeAccentSoft)
                 }
             }

--- a/Nudge/Views/Stats/WeeklyChartView.swift
+++ b/Nudge/Views/Stats/WeeklyChartView.swift
@@ -15,7 +15,7 @@ struct WeeklyChartView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
             Text(String(localized: "stats_chart_title"))
-                .font(.system(size: FontSize.xs))
+                .font(.system(size: FontSize.sm))
                 .foregroundStyle(Theme.nudgeTextMuted)
 
             Chart(data) { stat in


### PR DESCRIPTION
## Summary
Minor typography and string polish across PrimaryHeaderView, WeeklyChartView and motivation messages.

## Changes
- Added `IconSize.xs = 14` to `Constants.swift`
- Updated `PrimaryHeaderView` — subtitle FontSize.sm→FontSize.md, icon FontSize.xs→IconSize.xs
- Updated `WeeklyChartView` — chart title FontSize.xs→FontSize.sm
- Updated `Localizable.xcstrings` — removed trailing dots from motivation strings

## Why
- Subtitle and icon needed better visual balance
- Chart title was too small to read comfortably
- Motivation strings looked inconsistent with dots

## Result
Cleaner typography hierarchy and consistent string formatting.