### PR TITLE
chore: extract Height enum from Spacing in Constants

### DIFF
--- a/Nudge/Core/Constants.swift
+++ b/Nudge/Core/Constants.swift
@@ -17,10 +17,14 @@ enum Spacing {
     static let lg: CGFloat = 20
     static let xl: CGFloat = 24
     static let xxl: CGFloat = 32
+}
 
-    static let buttonHeight: CGFloat = 56
-    static let tabBarHeight: CGFloat = 62
-    static let chartHeight: CGFloat = 120
+// ====== Height ===============
+
+enum Height {
+    static let button: CGFloat = 56
+    static let tabBar: CGFloat = 62
+    static let chart: CGFloat = 120
 }
 
 // ====== Corner Radius ===============
@@ -48,13 +52,11 @@ enum FontSize {
 // ====== Icon Size ===============
 
 enum IconSize {
-    
     static let xs: CGFloat = 14
     static let sm: CGFloat = 16
     static let md: CGFloat = 20
     static let lg: CGFloat = 24
     static let xl: CGFloat = 32
-
     static let checkButton: CGFloat = 44
     static let profileAvatar: CGFloat = 56
     static let avatar: CGFloat = 72

--- a/Nudge/Views/Components/PrimaryButtonView.swift
+++ b/Nudge/Views/Components/PrimaryButtonView.swift
@@ -27,7 +27,7 @@ struct PrimaryButtonView: View {
                 }
             }
             .frame(maxWidth: .infinity)
-            .frame(height: Spacing.buttonHeight)
+            .frame(height: Height.button)
             .background(isDisabled ? Theme.nudgeTextMuted : Theme.nudgeAccent)
             .clipShape(RoundedRectangle(cornerRadius: Radius.full))
         }

--- a/Nudge/Views/Components/TabBarView.swift
+++ b/Nudge/Views/Components/TabBarView.swift
@@ -38,7 +38,7 @@ struct TabBarView: View {
             }
         }
         .padding(Spacing.xs)
-        .frame(height: Spacing.tabBarHeight)
+        .frame(height: Height.tabBar)
         .background(Theme.nudgeSurface)
         .clipShape(Capsule())
         .padding(.horizontal, Spacing.lg)

--- a/Nudge/Views/Stats/WeeklyChartView.swift
+++ b/Nudge/Views/Stats/WeeklyChartView.swift
@@ -32,7 +32,7 @@ struct WeeklyChartView: View {
                 )
                 .cornerRadius(Radius.sm)
             }
-            .frame(height: Spacing.chartHeight)
+            .frame(height: Height.chart)
             .chartXAxis {
                 AxisMarks { _ in
                     AxisValueLabel()


### PR DESCRIPTION
## Summary
Moved height-specific constants out of Spacing into a dedicated Height enum.

## Changes
- Added `Height` enum with `button`, `tabBar` and `chart`
- Removed `buttonHeight`, `tabBarHeight` and `chartHeight` from `Spacing`
- Updated `PrimaryButtonView`, `TabBarView` and `WeeklyChartView` to use `Height`

## Why
Height values are not spacing — they belong in their own enum for clarity.

## Result
Constants are now grouped by responsibility.