### PR TITLE
chore: remove file headers, standardize section dividers across all files

### DIFF
--- a/Nudge/Core/Constants.swift
+++ b/Nudge/Core/Constants.swift
@@ -1,13 +1,6 @@
-//
-//  Constants.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-04-28.
-//
-
 import Foundation
 
-// ====== Spacing ===============
+//==== Spacing =============================================
 
 enum Spacing {
     static let none: CGFloat = 0
@@ -19,7 +12,7 @@ enum Spacing {
     static let xxl: CGFloat = 32
 }
 
-// ====== Height ===============
+//==== Height =============================================
 
 enum Height {
     static let button: CGFloat = 56
@@ -27,7 +20,7 @@ enum Height {
     static let chart: CGFloat = 120
 }
 
-// ====== Corner Radius ===============
+//==== Corner Radius =============================================
 
 enum Radius {
     static let sm: CGFloat = 12
@@ -37,7 +30,7 @@ enum Radius {
     static let full: CGFloat = 999
 }
 
-// ====== Font Size ===============
+//==== Font Size =============================================
 
 enum FontSize {
     static let xs: CGFloat = 10
@@ -49,7 +42,7 @@ enum FontSize {
     static let display: CGFloat = 26
 }
 
-// ====== Icon Size ===============
+//==== Icon Size =============================================
 
 enum IconSize {
     static let xs: CGFloat = 14

--- a/Nudge/Core/Presets.swift
+++ b/Nudge/Core/Presets.swift
@@ -1,11 +1,6 @@
-//
-//  Symbols.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-05-05.
-//
-
 import Foundation
+
+//==== Symbols =============================================
 
 enum Symbols {
 
@@ -53,6 +48,7 @@ enum Symbols {
     ]
 }
 
+//==== Categories =============================================
 
 enum Categories {
     static let habitCategories = [

--- a/Nudge/Core/Theme.swift
+++ b/Nudge/Core/Theme.swift
@@ -1,32 +1,25 @@
-//
-//  Theme.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-04-28.
-//
-
 import SwiftUI
 
 struct Theme {
 
     //==== Backgrounds =============================================
-    
+
     static let nudgeBackground = Color("Background")
     static let nudgeSurface = Color("Surface")
     static let nudgeCard = Color("Card")
 
     //==== Accent =============================================
-    
+
     static let nudgeAccent = Color("Accent")
     static let nudgeAccentLight = Color("AccentLight")
     static let nudgeAccentSoft = Color("AccentSoft")
 
     //==== Feedback =============================================
-    
+
     static let nudgeSuccess = Color("Success")
 
     //==== Text =============================================
-    
+
     static let nudgeTextPrimary = Color("TextPrimary")
     static let nudgeTextMuted = Color("TextMuted")
 }

--- a/Nudge/Models/DayStat.swift
+++ b/Nudge/Models/DayStat.swift
@@ -1,17 +1,14 @@
-//
-//  DayStat.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-05-05.
-//
-
 import Foundation
 
 struct DayStat: Identifiable {
 
+    //==== Properties =============================================
+
     let id = UUID()
     let date: Date
     let count: Int
+
+    //==== Computed =============================================
 
     var weekdayLabel: String {
         date.formatted(.dateTime.weekday(.abbreviated))

--- a/Nudge/Models/Habit.swift
+++ b/Nudge/Models/Habit.swift
@@ -1,13 +1,8 @@
-//
-//  Habit.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-04-28.
-//
-
 import Foundation
 
 struct Habit: Identifiable, Codable {
+
+    //==== Properties =============================================
 
     let id: String
     let userId: String

--- a/Nudge/Models/Tab.swift
+++ b/Nudge/Models/Tab.swift
@@ -1,11 +1,6 @@
-//
-//  Tab.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-05-04.
-//
-
 import Foundation
+
+//==== Tab =============================================
 
 enum Tab {
     case profile, stats, habits

--- a/Nudge/NudgeApp.swift
+++ b/Nudge/NudgeApp.swift
@@ -1,25 +1,24 @@
-//
-//  NudgeApp.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-04-28.
-//
-
-import SwiftUI
 import FirebaseCore
+import SwiftUI
 
 @main
 struct NudgeApp: App {
 
+    //==== State =============================================
+
     @State private var authViewModel: AuthViewModel
     @State private var habitViewModel: HabitViewModel
     @State private var statsViewModel = StatsViewModel()
-    
+
+    //==== Init =============================================
+
     init() {
         FirebaseApp.configure()
         _authViewModel = State(initialValue: AuthViewModel())
         _habitViewModel = State(initialValue: HabitViewModel(habitService: HabitService()))
     }
+
+    //==== Body =============================================
 
     var body: some Scene {
         WindowGroup {

--- a/Nudge/Services/Auth/AuthService.swift
+++ b/Nudge/Services/Auth/AuthService.swift
@@ -1,12 +1,16 @@
-import Foundation
 import FirebaseAuth
+import Foundation
 
 final class AuthService: AuthServiceProtocol {
+
+    //==== Sign In =============================================
 
     func signIn(email: String, password: String) async throws -> User {
         let result = try await Auth.auth().signIn(withEmail: email, password: password)
         return result.user
     }
+
+    //==== Sign Up =============================================
 
     func signUp(email: String, password: String, name: String) async throws -> User {
         let result = try await Auth.auth().createUser(withEmail: email, password: password)
@@ -14,11 +18,15 @@ final class AuthService: AuthServiceProtocol {
         changeRequest.displayName = name
         try await changeRequest.commitChanges()
         return Auth.auth().currentUser ?? result.user
-    }   
+    }
+
+    //==== Sign Out =============================================
 
     func signOut() throws {
         try Auth.auth().signOut()
     }
+
+    //==== Listener =============================================
 
     func addStateDidChangeListener(_ listener: @escaping (User?) -> Void) -> AuthStateDidChangeListenerHandle {
         Auth.auth().addStateDidChangeListener { _, user in

--- a/Nudge/Services/Auth/AuthServiceProtocol.swift
+++ b/Nudge/Services/Auth/AuthServiceProtocol.swift
@@ -1,16 +1,21 @@
-//
-//  AuthServiceProtocol.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-04-30.
-//
-
-import Foundation
 import FirebaseAuth
+import Foundation
 
 protocol AuthServiceProtocol {
+
+    //==== Sign In =============================================
+
     func signIn(email: String, password: String) async throws -> User
+
+    //==== Sign Up =============================================
+
     func signUp(email: String, password: String, name: String) async throws -> User
+
+    //==== Sign Out =============================================
+
     func signOut() throws
+
+    //==== Listener =============================================
+
     func addStateDidChangeListener(_ listener: @escaping (User?) -> Void) -> AuthStateDidChangeListenerHandle
 }

--- a/Nudge/Services/Habit/HabitService.swift
+++ b/Nudge/Services/Habit/HabitService.swift
@@ -1,12 +1,5 @@
-//
-//  HabitService.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-05-01.
-//
-
-import Foundation
 import FirebaseFirestore
+import Foundation
 
 final class HabitService: HabitServiceProtocol {
 
@@ -34,7 +27,7 @@ final class HabitService: HabitServiceProtocol {
             .document(habit.id)
             .setData(from: habit)
     }
-    
+
     //==== Update =============================================
 
     func updateHabit(_ habit: Habit) async throws {
@@ -51,7 +44,7 @@ final class HabitService: HabitServiceProtocol {
             .delete()
     }
 
-    //==== Check-In =============================================
+    //==== Check In =============================================
 
     func checkIn(_ habit: Habit, on date: Date) async throws {
         let timestamp = Timestamp(date: date)
@@ -61,5 +54,4 @@ final class HabitService: HabitServiceProtocol {
                 "completedDates": FieldValue.arrayUnion([timestamp])
             ])
     }
-
 }

--- a/Nudge/Services/Habit/HabitServiceProtocol.swift
+++ b/Nudge/Services/Habit/HabitServiceProtocol.swift
@@ -1,16 +1,24 @@
-//
-//  HabitServiceProtocol.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-05-01.
-//
-
 import Foundation
 
 protocol HabitServiceProtocol {
+
+    //==== Fetch =============================================
+
     func fetchHabits(for userId: String) async throws -> [Habit]
+
+    //==== Add =============================================
+
     func addHabit(_ habit: Habit) async throws
+
+    //==== Update =============================================
+
     func updateHabit(_ habit: Habit) async throws
+
+    //==== Delete =============================================
+
     func deleteHabit(_ habit: Habit) async throws
+
+    //==== Check In =============================================
+
     func checkIn(_ habit: Habit, on date: Date) async throws
 }

--- a/Nudge/ViewModels/AuthViewModel.swift
+++ b/Nudge/ViewModels/AuthViewModel.swift
@@ -1,10 +1,3 @@
-//
-//  AuthViewModel.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-04-28.
-//
-
 import FirebaseAuth
 import Foundation
 

--- a/Nudge/ViewModels/HabitViewModel.swift
+++ b/Nudge/ViewModels/HabitViewModel.swift
@@ -1,10 +1,3 @@
-//
-//  HabitViewModel.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-04-28.
-//
-
 import Foundation
 
 @Observable
@@ -44,9 +37,9 @@ final class HabitViewModel {
         ]
         return messages[totalCheckIns % messages.count]
     }
-    
+
     var habitsByCategory: [String: [Habit]] {
-           Dictionary(grouping: habits, by: { $0.category })
+        Dictionary(grouping: habits, by: { $0.category })
     }
 
     //==== Fetch =============================================
@@ -63,8 +56,8 @@ final class HabitViewModel {
 
         isLoading = false
     }
-   
-   //==== Add =======================================
+
+    //==== Add =============================================
 
     func addHabit(name: String, icon: String, category: String, userId: String) async {
         guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
@@ -88,8 +81,8 @@ final class HabitViewModel {
         } catch {
             errorMessage = String(localized: "error_save_failed")
         }
-   }
-    
+    }
+
     //==== Update =============================================
 
     func updateHabit(_ habit: Habit) async {
@@ -103,15 +96,15 @@ final class HabitViewModel {
         }
     }
 
-   //==== Delete =============================================
+    //==== Delete =============================================
 
     func deleteHabit(_ habit: Habit) async {
-          do {
-                try await habitService.deleteHabit(habit)
-                habits.removeAll { $0.id == habit.id }
-          } catch {
-                errorMessage = String(localized: "error_save_failed")
-          }
+        do {
+            try await habitService.deleteHabit(habit)
+            habits.removeAll { $0.id == habit.id }
+        } catch {
+            errorMessage = String(localized: "error_save_failed")
+        }
     }
 
     //==== Check In =============================================

--- a/Nudge/ViewModels/StatsViewModel.swift
+++ b/Nudge/ViewModels/StatsViewModel.swift
@@ -1,10 +1,3 @@
-//
-//  StatsViewModel.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-04-28.
-//
-
 import Foundation
 
 @Observable
@@ -40,13 +33,13 @@ final class StatsViewModel {
             return DayStat(date: date, count: count)
         }
     }
-    
+
     func statsMessage(for habits: [Habit]) -> String {
-           let total = totalCheckInsThisWeek(for: habits)
-           return total > 0
-               ? "\(total) \(String(localized: "stats_total"))"
-               : String(localized: "stats_no_checkins")
-       }
+        let total = totalCheckInsThisWeek(for: habits)
+        return total > 0
+            ? "\(total) \(String(localized: "stats_total"))"
+            : String(localized: "stats_no_checkins")
+    }
 
     //==== Private =============================================
 

--- a/Nudge/Views/AppNavigationView.swift
+++ b/Nudge/Views/AppNavigationView.swift
@@ -1,16 +1,16 @@
-//
-//  AppNavigationView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-05-04.
-//
-
 import SwiftUI
 
 struct AppNavigationView: View {
 
+    //==== Environment =============================================
+
     @Environment(AuthViewModel.self) private var authVM
+
+    //==== State =============================================
+
     @State private var selectedTab: Tab = .profile
+
+    //==== Body =============================================
 
     var body: some View {
         if authVM.currentUser != nil {

--- a/Nudge/Views/Auth/SignInView.swift
+++ b/Nudge/Views/Auth/SignInView.swift
@@ -1,10 +1,3 @@
-//
-//  SignInView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-04-28.
-//
-
 import SwiftUI
 
 struct SignInView: View {
@@ -27,8 +20,6 @@ struct SignInView: View {
 
             VStack(spacing: Spacing.xl) {
 
-                //==== Logo =============================================
-
                 VStack(spacing: Spacing.sm) {
                     ZStack {
                         Circle()
@@ -48,8 +39,6 @@ struct SignInView: View {
                 .padding(.top, Spacing.xxl)
                 .padding(.bottom, Spacing.xl)
 
-                //==== Form =============================================
-
                 VStack(spacing: Spacing.sm) {
                     InputFieldView(icon: "envelope", key: "auth_signin_email", text: $email)
                         .keyboardType(.emailAddress)
@@ -66,8 +55,6 @@ struct SignInView: View {
                     }
                 }
 
-                //==== Sign In Button =============================================
-
                 PrimaryButtonView(
                     label: String(localized: "auth_signin_title"),
                     isLoading: authVM.isLoading
@@ -78,8 +65,6 @@ struct SignInView: View {
                 }
 
                 Spacer()
-
-                //==== Sign Up Link =============================================
 
                 HStack(spacing: Spacing.xs) {
                     Text(String(localized: "auth_signin_no_account"))

--- a/Nudge/Views/Auth/SignUpView.swift
+++ b/Nudge/Views/Auth/SignUpView.swift
@@ -1,10 +1,3 @@
-//
-//  SignUpView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-04-28.
-//
-
 import SwiftUI
 
 struct SignUpView: View {
@@ -28,14 +21,10 @@ struct SignUpView: View {
 
             VStack(spacing: Spacing.xxl) {
 
-                //==== Header =============================================
-
                 PrimaryHeaderView(
                     title: String(localized: "auth_signup_title"),
                     subtitle: String(localized: "auth_signup_subtitle")
                 )
-
-                //==== Form =============================================
 
                 VStack(spacing: Spacing.sm) {
                     InputFieldView(
@@ -62,8 +51,6 @@ struct SignUpView: View {
                         isSecure: true
                     )
                 }
-
-                //==== Create Account Button =============================================
 
                 VStack(spacing: Spacing.md) {
                     PrimaryButtonView(

--- a/Nudge/Views/Components/CategoryListView.swift
+++ b/Nudge/Views/Components/CategoryListView.swift
@@ -1,19 +1,16 @@
-//
-//  CategoryListView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-05-07.
-//
-
 import SwiftUI
 
 struct CategoryListView: View {
+
+    //==== Properties =============================================
 
     let habitsByCategory: [String: [Habit]]
     var onCheckIn: ((Habit) -> Void)? = nil
     var onDelete: ((Habit) -> Void)? = nil
     var onEdit: ((Habit) -> Void)? = nil
     var statsVM: StatsViewModel? = nil
+
+    //==== Body =============================================
 
     var body: some View {
         List {

--- a/Nudge/Views/Components/CategoryPickerView.swift
+++ b/Nudge/Views/Components/CategoryPickerView.swift
@@ -1,16 +1,13 @@
-//
-//  CategoryPickerView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-05-06.
-//
-
 import SwiftUI
 
 struct CategoryPickerView: View {
 
+    //==== Properties =============================================
+
     @Binding var selectedCategory: String
     @State private var isExpanded = false
+
+    //==== Body =============================================
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
@@ -28,7 +25,8 @@ struct CategoryPickerView: View {
             if isExpanded {
                 PrimaryCardView {
                     VStack(spacing: Spacing.xs) {
-                        ForEach(Categories.habitCategories, id: \.self) { category in
+                        ForEach(Categories.habitCategories, id: \.self) {
+                            category in
                             Button {
                                 selectedCategory = category
                                 withAnimation {
@@ -38,7 +36,11 @@ struct CategoryPickerView: View {
                                 HStack {
                                     Text(category)
                                         .font(.system(size: FontSize.md))
-                                        .foregroundStyle(selectedCategory == category ? Theme.nudgeTextPrimary : Theme.nudgeTextMuted)
+                                        .foregroundStyle(
+                                            selectedCategory == category
+                                                ? Theme.nudgeTextPrimary
+                                                : Theme.nudgeTextMuted
+                                        )
                                     Spacer()
                                     if selectedCategory == category {
                                         Image(systemName: "checkmark")

--- a/Nudge/Views/Components/HabitRowView.swift
+++ b/Nudge/Views/Components/HabitRowView.swift
@@ -1,10 +1,3 @@
-//
-//  HabitRowView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-04-28.
-//
-
 import SwiftUI
 
 struct HabitRowView: View {

--- a/Nudge/Views/Components/IconPickerView.swift
+++ b/Nudge/Views/Components/IconPickerView.swift
@@ -1,18 +1,15 @@
-//
-//  IconPickerView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-04-28.
-//
-
 import SwiftUI
 
 struct IconPickerView: View {
+
+    //==== Properties =============================================
 
     @Binding var selectedIcon: String
     @State private var isExpanded = false
 
     private let columns = Array(repeating: GridItem(.flexible()), count: 4)
+
+    //==== Body =============================================
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {

--- a/Nudge/Views/Components/InputFieldView.swift
+++ b/Nudge/Views/Components/InputFieldView.swift
@@ -1,16 +1,21 @@
 import SwiftUI
 
 struct InputFieldView: View {
+
+    //==== Properties =============================================
+
     let icon: String
     let key: String.LocalizationValue
     @Binding var text: String
     var isSecure: Bool = false
 
+    //==== Body =============================================
+
     var body: some View {
         HStack(spacing: Spacing.sm) {
             Image(systemName: icon)
                 .foregroundStyle(Theme.nudgeTextMuted)
-            
+
             Group {
                 if isSecure {
                     SecureField("", text: $text, prompt: prompt)
@@ -24,6 +29,8 @@ struct InputFieldView: View {
         .background(Theme.nudgeCard)
         .clipShape(RoundedRectangle(cornerRadius: Radius.lg))
     }
+
+    //==== Private =============================================
 
     private var prompt: Text {
         Text(String(localized: key))

--- a/Nudge/Views/Components/NameFieldView.swift
+++ b/Nudge/Views/Components/NameFieldView.swift
@@ -1,15 +1,12 @@
-//
-//  NameFieldView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-05-06.
-//
-
 import SwiftUI
 
 struct NameFieldView: View {
 
+    //==== Properties =============================================
+
     @Binding var text: String
+
+    //==== Body =============================================
 
     var body: some View {
         HStack(spacing: Spacing.sm) {

--- a/Nudge/Views/Components/PickerHeaderView.swift
+++ b/Nudge/Views/Components/PickerHeaderView.swift
@@ -1,18 +1,15 @@
-//
-//  PickerHeaderView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-05-06.
-//
-
 import SwiftUI
 
 struct PickerHeaderView: View {
+
+    //==== Properties =============================================
 
     let label: String
     let isExpanded: Bool
     var leadingIcon: String? = nil
     let action: () -> Void
+
+    //==== Body =============================================
 
     var body: some View {
         Button(action: action) {

--- a/Nudge/Views/Components/PrimaryButtonView.swift
+++ b/Nudge/Views/Components/PrimaryButtonView.swift
@@ -1,18 +1,15 @@
-//
-//  PrimaryButtonView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-05-06.
-//
-
 import SwiftUI
 
 struct PrimaryButtonView: View {
+
+    //==== Properties =============================================
 
     let label: String
     var isLoading: Bool = false
     var isDisabled: Bool = false
     let action: () -> Void
+
+    //==== Body =============================================
 
     var body: some View {
         Button(action: action) {

--- a/Nudge/Views/Components/PrimaryCardView.swift
+++ b/Nudge/Views/Components/PrimaryCardView.swift
@@ -1,15 +1,12 @@
-//
-//  PrimaryCardView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-05-06.
-//
-
 import SwiftUI
 
 struct PrimaryCardView<Content: View>: View {
 
+    //==== Properties =============================================
+
     @ViewBuilder let content: () -> Content
+
+    //==== Body =============================================
 
     var body: some View {
         content()

--- a/Nudge/Views/Components/PrimaryHeaderView.swift
+++ b/Nudge/Views/Components/PrimaryHeaderView.swift
@@ -1,13 +1,8 @@
-//
-//  PrimaryHeaderView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-05-06.
-//
-
 import SwiftUI
 
 struct PrimaryHeaderView: View {
+
+    //==== Properties =============================================
 
     let title: String
     let subtitle: String
@@ -16,6 +11,8 @@ struct PrimaryHeaderView: View {
     var onAdd: (() -> Void)? = nil
     var trailingText: String? = nil
     var trailingColor: Color = Theme.nudgeTextMuted
+
+    //==== Body =============================================
 
     var body: some View {
         HStack(alignment: .top) {

--- a/Nudge/Views/Components/TabBarView.swift
+++ b/Nudge/Views/Components/TabBarView.swift
@@ -1,15 +1,12 @@
-//
-//  TabBarView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-05-04.
-//
-
 import SwiftUI
 
 struct TabBarView: View {
 
+    //==== Properties =============================================
+
     @Binding var selectedTab: Tab
+
+    //==== Body =============================================
 
     var body: some View {
         HStack(spacing: 0) {
@@ -51,10 +48,14 @@ struct TabBarView: View {
 
 private struct TabBarButton: View {
 
+    //==== Properties =============================================
+
     let icon: String
     let label: String
     let isSelected: Bool
     let action: () -> Void
+
+    //==== Body =============================================
 
     var body: some View {
         Button(action: action) {

--- a/Nudge/Views/Habits/HabitFormView.swift
+++ b/Nudge/Views/Habits/HabitFormView.swift
@@ -1,10 +1,3 @@
-//
-//  HabitFormView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-04-28.
-//
-
 import SwiftUI
 
 struct HabitFormView: View {

--- a/Nudge/Views/Habits/HabitsView.swift
+++ b/Nudge/Views/Habits/HabitsView.swift
@@ -1,10 +1,3 @@
-//
-//  HabitsView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-04-28.
-//
-
 import SwiftUI
 
 struct HabitsView: View {

--- a/Nudge/Views/Profile/HeroView.swift
+++ b/Nudge/Views/Profile/HeroView.swift
@@ -1,18 +1,15 @@
-//
-//  HeroView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-05-06.
-//
-
 import SwiftUI
 
 struct HeroView: View {
+
+    //==== Properties =============================================
 
     let userInitial: String
     let displayName: String
     let memberSince: String
     let onSignOut: () -> Void
+
+    //==== Body =============================================
 
     var body: some View {
         HStack(spacing: Spacing.md) {

--- a/Nudge/Views/Profile/ProfileView.swift
+++ b/Nudge/Views/Profile/ProfileView.swift
@@ -1,10 +1,3 @@
-//
-//  ProfileView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-04-28.
-//
-
 import SwiftUI
 
 struct ProfileView: View {

--- a/Nudge/Views/Stats/StatsView.swift
+++ b/Nudge/Views/Stats/StatsView.swift
@@ -1,10 +1,3 @@
-//
-//  StatsView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-04-28.
-//
-
 import SwiftUI
 
 struct StatsView: View {

--- a/Nudge/Views/Stats/WeeklyChartView.swift
+++ b/Nudge/Views/Stats/WeeklyChartView.swift
@@ -1,16 +1,13 @@
-//
-//  WeeklyChartView.swift
-//  Nudge
-//
-//  Created by Linnéa on 2026-04-28.
-//
-
 import Charts
 import SwiftUI
 
 struct WeeklyChartView: View {
 
+    //==== Properties =============================================
+
     let data: [DayStat]
+
+    //==== Body =============================================
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {


### PR DESCRIPTION
## Summary
Cleaned up all Swift files — removed auto-generated file headers and standardized section dividers to use a consistent style throughout the codebase.

## Changes
- Removed file headers (filename, project name, created by) from all files
- Standardized all section dividers to `//==== Section =============================================`
- Added missing dividers to files that lacked them
- Fixed inconsistent divider lengths in HabitViewModel and HabitService

## Why
File headers add no value — the information is already in Git and Xcode. Consistent dividers make the codebase easier to scan and maintain.

## Result
All files follow the same comment style throughout the project.